### PR TITLE
Change. Sockets does not close when they detects ETERM.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ script:
   - lua -lluacov test_threads_file.lua
   - lua -lluacov test_threads_actor.lua
   - lua -lluacov test_threads_actor_poll.lua
+  - lua -lluacov test_threads_sync.lua
   - lua -lluacov test_metadata.lua
   #- if [ "$ZMQ_VER" == "libzmq" ]; then
   #    lua test_req_relaxed.lua;

--- a/lakefile
+++ b/lakefile
@@ -85,6 +85,7 @@ target('test', install, function()
   run_test('test_metadata.lua')
   run_test('test_threads_actor.lua')
   run_test('test_threads_actor_poll.lua')
+  run_test('test_threads_sync.lua')
 
   if not test_summary() then
     quit("test fail")

--- a/src/lzmq.c
+++ b/src/lzmq.c
@@ -78,15 +78,20 @@ int luazmq_pass(lua_State *L){
 
 static int luazmq_geterrno(lua_State *L, zsocket *skt){
   int err = zmq_errno();
+  /* After we get ETERM error we can still use this socket
+   * to syncronize between threads. So this make sense to not close it.
+   */
   if(skt && (err == ETERM)){
     if(!(skt->flags & LUAZMQ_FLAG_CLOSED)){
-      /*int ret = */zmq_close(skt->skt);
-      skt->flags |= LUAZMQ_FLAG_CLOSED;
-      luazmq_skt_before_close(L, skt);
+      if(skt->flags & LUAZMQ_FLAG_CLOSE_ON_ETERM){
+        /*int ret = */zmq_close(skt->skt);
+        skt->flags |= LUAZMQ_FLAG_CLOSED;
+        luazmq_skt_before_close(L, skt);
 #if LZMQ_SOCKET_COUNT
-      skt->ctx->socket_count--;
-      assert(skt->ctx->socket_count >= 0);
+        skt->ctx->socket_count--;
+        assert(skt->ctx->socket_count >= 0);
 #endif
+      }
     }
   }
   return err;

--- a/src/lzmq.h
+++ b/src/lzmq.h
@@ -35,11 +35,12 @@
 #define LUAZMQ_PREFIX  "LuaZMQ: "
 
 typedef unsigned char uchar;
-#define LUAZMQ_FLAG_CLOSED       (uchar)(0x01 << 0)
+#define LUAZMQ_FLAG_CLOSED         (uchar)(0x01 << 0)
 /*context only*/
-#define LUAZMQ_FLAG_CTX_SHUTDOWN (uchar)(0x01 << 1)
-#define LUAZMQ_FLAG_DONT_DESTROY (uchar)(0x01 << 2)
-#define LUAZMQ_FLAG_MORE         (uchar)(0x01 << 3)
+#define LUAZMQ_FLAG_CTX_SHUTDOWN   (uchar)(0x01 << 1)
+#define LUAZMQ_FLAG_DONT_DESTROY   (uchar)(0x01 << 2)
+#define LUAZMQ_FLAG_MORE           (uchar)(0x01 << 3)
+#define LUAZMQ_FLAG_CLOSE_ON_ETERM (uchar)(0x01 << 4)
 
 typedef struct{
   void  *ctx;

--- a/test/test_threads_sync.lua
+++ b/test/test_threads_sync.lua
@@ -1,0 +1,50 @@
+local TEST_FFI = ("ffi" == os.getenv("LZMQ"))
+local LZMQ     = "lzmq" .. (TEST_FFI and ".ffi" or "")
+
+local zmq      = require (LZMQ)
+local zthreads = require (LZMQ .. ".threads" )
+
+local ctx = zmq:context()
+
+local thread, skt = zthreads.fork(ctx, string.dump(function(skt)
+  local ztimer = require "lzmq.timer"
+
+  local function assert_equal(name, a, b, ...)
+    if a == b then return b, ... end
+    print(name .. " Fail! Expected `" .. tostring(a) .. "` got `" .. tostring(b) .. "`")
+    os.exit(1)
+  end
+
+  local function assert_not_nil(name, a, ...)
+    if a ~= nil then return a, ... end
+    print(name .. " Fail! Expected not nil value but got it.")
+    os.exit(1)
+  end
+
+  skt:send("")
+  while true do
+    local msg, err = skt:recv()
+    if not msg then 
+      assert_not_nil("Error", err)
+      assert_equal("Error", "ETERM", err:mnemo())
+      break
+    end
+  end
+
+  -- wait to ensure 
+  ztimer.sleep(5000)
+
+  print("Done!")
+  os.exit(0)
+end))
+
+thread:start()
+
+skt:recv()
+
+-- we should wait until socket in thread not closed
+ctx:destroy()
+
+print('Sync does not work.')
+
+os.exit(2)


### PR DESCRIPTION
Close #22.
Also this is current bihavior fo `lzmq-ffi` version
