### PR TITLE
use rawset when initializing child thread args

### DIFF
--- a/src/lua/lzmq/llthreads/ex.lua
+++ b/src/lua/lzmq/llthreads/ex.lua
@@ -71,8 +71,8 @@ local bootstrap_code = require"string".dump(function(lua_init, prelude, code, ..
   local func
   func, args[0] = load_src(code)
 
-  _G.arg = args
-     arg = args
+  rawset(_G, "arg", args)
+  arg = args
 
   return func(unpack_n(args))
 end)


### PR DESCRIPTION
it is possible for someone to mess with the global table in the prelude or lua_init phases of thread creation. For instance, one could disable the creation of global variables via the _G __newindex metatable method. Then the thread spawning code would not work correctly. For this reason we should not rely on normal insertion into _G and instead use rawset