### PR TITLE
Add. Handle socket fd as lightuserdata on Windows.

### DIFF
--- a/src/lzutils.h
+++ b/src/lzutils.h
@@ -11,8 +11,18 @@
 #ifndef _LZUTILS_H_
 #define _LZUTILS_H_
 
+#if defined(_WIN32)
+#include <winsock2.h>
+#endif
+
 #include "lua.h"
 #include "lauxlib.h"
+
+#if defined(_WIN32)
+typedef SOCKET lzmq_os_sock_t;
+#else
+typedef int    lzmq_os_sock_t;
+#endif
 
 #if LUA_VERSION_NUM >= 503 /* Lua 5.3 */
 
@@ -98,5 +108,9 @@ int luazmq_call_method(lua_State *L, const char *name, int nargs, int nresults);
 int luazmq_new_weak_table(lua_State*L, const char *mode);
 
 void luazmq_stack_dump(lua_State *L);
+
+lzmq_os_sock_t luazmq_check_os_socket(lua_State *L, int idx, const char *msg);
+
+void luazmq_push_os_socket(lua_State *L, lzmq_os_sock_t fd);
 
 #endif

--- a/src/zcontext.c
+++ b/src/zcontext.c
@@ -470,6 +470,7 @@ static const luazmq_int_const ctx_options[] = {
   DEFINE_ZMQ_CONST(MAX_MSGSZ),
 #endif
 
+  {NULL,NULL}
 };
 
 void luazmq_context_initlib (lua_State *L, int nup){

--- a/src/zpoller.c
+++ b/src/zpoller.c
@@ -14,13 +14,9 @@
 #include "lzmq.h"
 #include <assert.h>
 
-static socket_t luazmq_checksocket_fd(lua_State *L, int idx);
-
-socket_t luazmq_checksocket_fd(lua_State *L, int idx){
-  if(sizeof(lua_Integer) >= sizeof(socket_t))
-    return luaL_checkinteger(L, idx);
-  return (socket_t)luaL_checknumber(L, idx);
-}
+#define luazmq_check_socket(L, idx, zs, fd) \
+  if (lua_isuserdata(L, idx) && !lua_islightuserdata(L, idx)) zs = luazmq_getsocket_at(L, idx);\
+  else fd = (socket_t)luazmq_check_os_socket(L, idx, "number or ZMQ socket");
 
 #define LUAZMQ_DEFAULT_POLLER_LEN 10
 
@@ -59,9 +55,7 @@ static int luazmq_plr_add(lua_State *L) {
   zsocket *sock = NULL;
   socket_t fd = 0;
 
-  if(lua_isuserdata(L, 2)) sock = luazmq_getsocket_at(L, 2);
-  else if(lua_isnumber(L, 2)) fd = luazmq_checksocket_fd(L, 2);
-  else return luazmq_typerror(L, 2, "number or ZMQ socket");
+  luazmq_check_socket(L, 2, sock, fd);
 
   idx = poller_get_free_item(poller);
   item = &(poller->items[idx]);
@@ -82,15 +76,12 @@ static int luazmq_plr_modify(lua_State *L){
   zsocket *sock = NULL;
   socket_t fd = 0;
 
-  if(lua_isuserdata(L, 2)) {
-    sock = luazmq_getsocket_at(L, 2);
+  luazmq_check_socket(L, 2, sock, fd);
+
+  if(sock)
     idx = poller_find_sock_item(poller, sock->skt);
-  } else if(lua_isnumber(L, 2)) {
-    fd = luazmq_checksocket_fd(L, 2);
+  else
     idx = poller_find_fd_item(poller, fd);
-  } else {
-    return luazmq_typerror(L, 2, "number or ZMQ socket");
-  }
 
   if(events != 0) {
     if(idx < 0) idx = poller_get_free_item(poller);
@@ -111,16 +102,15 @@ static int luazmq_plr_modify(lua_State *L){
 static int luazmq_plr_remove(lua_State *L) {
   zpoller *poller = luazmq_getpoller(L);
   int idx = 0;
+  zsocket *sock = NULL;
+  socket_t fd = 0;
 
-  if(lua_isuserdata(L, 2)) {
-    zsocket *sock = luazmq_getsocket_at(L, 2);
+  luazmq_check_socket(L, 2, sock, fd);
+
+  if(sock)
     idx = poller_find_sock_item(poller, sock->skt);
-  } else if(lua_isnumber(L, 2)) {
-    socket_t fd = luazmq_checksocket_fd(L, 2);
+  else
     idx = poller_find_fd_item(poller, fd);
-  } else {
-    return luazmq_typerror(L, 2, "number or ZMQ socket");
-  }
 
   /* if sock/fd was found. */
   if(idx >= 0) {

--- a/src/zsocket.c
+++ b/src/zsocket.c
@@ -18,21 +18,7 @@
 #include <memory.h>
 #include <stdlib.h>
 
-#if defined(_WIN32)
-typedef SOCKET fd_t;
-#else
-typedef int    fd_t;
-#endif
-
-static void luazmq_pushsocket_fd(lua_State *L, fd_t fd);
-
-void luazmq_pushsocket_fd(lua_State *L, fd_t fd){
-  if(sizeof(lua_Integer) <= sizeof(fd_t)){
-    lua_pushinteger(L, (lua_Integer)fd);
-    return;
-  }
-  lua_pushnumber(L, (lua_Number)fd);
-}
+#define fd_t lzmq_os_sock_t
 
 #define DEFINE_SKT_METHOD_1(NAME)              \
                                                \
@@ -848,20 +834,14 @@ static int luazmq_skt_get_fdt (lua_State *L, int option_name) {
   }
 
   if (ret == -1) return luazmq_fail(L, skt);
-  luazmq_pushsocket_fd(L, option_value);
+  luazmq_push_os_socket(L, option_value);
   return 1;
 }
 
 static int luazmq_skt_set_fdt (lua_State *L, int option_name) {
   zsocket *skt = luazmq_getsocket(L);
-  fd_t option_value;
+  fd_t option_value = luazmq_check_os_socket(L, 2, "file descriptor expected");
   int ret;
-  if(lua_islightuserdata(L, 2)){
-    option_value = (fd_t)lua_touserdata(L, 2);
-  }
-  else{
-    option_value = (fd_t)luaL_checknumber(L, 2);
-  }
   ret = zmq_setsockopt(skt->skt, option_name, &option_value, sizeof(option_value));
   if (ret == -1) return luazmq_fail(L, skt);
   return luazmq_pass(L);

--- a/test/utils.lua
+++ b/test/utils.lua
@@ -1,0 +1,39 @@
+local zmq = require "lzmq"
+
+io.stdout:setvbuf"no"
+
+function printf(...) return print(string.format(...)) end
+
+function print_msg(title, data, err, ...)
+  print(title)
+  if data then -- data
+    if type(data) == 'table' then
+      for _, msg in ipairs(data) do
+        printf("[%.4d] %s", #msg, msg) 
+      end
+    elseif type(data) == 'userdata'  then
+      printf("[%.4d] %s", data:size(), data:data()) 
+    else 
+      printf("[%.4d] %s", #data, data)
+    end
+  else  --error
+    if type(err) == 'string' then
+      printf("Error: %s", err)
+    elseif type(err) == 'number' then 
+      local msg   = zmq.error(err):msg()
+      local mnemo = zmq.errors[err] or 'UNKNOWN'
+      printf("Error: [%s] %s (%d)", mnemo, msg, err)
+    elseif type(err) == 'userdata' then
+      printf("Error: [%s] %s (%d)", err:mnemo(), err:msg(), err:no())
+    else
+      printf("Error: %s", tostring(err))
+    end
+  end
+  print("-------------------------------------")
+  return data, err, ...
+end
+
+function print_version(zmq)
+  local version = zmq.version()
+  printf("zmq version: %d.%d.%d", version[1], version[2], version[3])
+end


### PR DESCRIPTION
Problem that on Windows `SOCKET` type may not fit to Lua number type.
But to compatibility with old code `lzmq` rerurns `lightuserdata` only if Lua 
can not represent value as number.
Previous versions have an undefined behavior in such cases.